### PR TITLE
Build wheel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,8 @@ __pycache__
 data
 .venv
 
+build
+dist
+
 #tmp
 code_ref

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .venv:
 	python -m venv .venv
 	.venv/bin/pip install --upgrade pip
-	.venv/bin/pip install .[dev]
+	.venv/bin/pip install -e .[dev]
 
 
 build_qa: .venv

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .venv:
 	python -m venv .venv
 	.venv/bin/pip install --upgrade pip
-	.venv/bin/pip install -e .[dev]
+	.venv/bin/pip install -e .[dev,build]
 
 
 build_qa: .venv
@@ -13,6 +13,5 @@ build_qa: .venv
 	.venv/bin/pytest tests
 
 
-# TODO
-build_wheel:
-	echo "TODO"
+build_wheel: .venv
+	.venv/bin/python -m build --wheel

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .venv:
 	python -m venv .venv
 	.venv/bin/pip install --upgrade pip
-	.venv/bin/pip install -e .[dev,build]
+	.venv/bin/pip install -e .[dev,wheel]
 
 
 build_qa: .venv

--- a/Makefile
+++ b/Makefile
@@ -13,5 +13,5 @@ build_qa: .venv
 	.venv/bin/pytest tests
 
 
-build_wheel: .venv
+build: .venv
 	.venv/bin/python -m build --wheel

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,9 @@ dev = [
     "pytest",
     "ruff",
 ]
+wheel = [
+    "build",
+]
 
 [tool.setuptools.packages.find]
 include = ["external_resources"]


### PR DESCRIPTION
Tested locally and the wheel works. Currently just creates it and does
nothing with it.

Wheel path:
`dist\external_resources-0.0.1-py3-none-any.whl`

```
> pip install .\dist\external_resources-0.0.1-py3-none-any.whl
...
Successfully installed annotated-types-0.7.0 external-resources-0.0.1 pydantic-2.10.4 pydantic-core-2.27.2 typing-extensions-4.12.2

> python
Python 3.11.4 ...
>>> from external_resources.executables import GitExecutable, executable_type_defs
>>> GitExecutable().is_available()
True
>>> GitExecutable().use(executable_type_defs.ExecutableUseArgs(args=["branch"]))
ExecutableUseValue(return_code=0, stdout='* build_wheel\n  main\n', stderr='')
>>> exit()
> pip uninstall .\dist\external_resources-0.0.1-py3-none-any.whl
Found existing installation: external-resources 0.0.1
Uninstalling external-resources-0.0.1:
...
Proceed (Y/n)? Y
  Successfully uninstalled external-resources-0.0.1
```
