### PR TITLE
Add class to validate and manage resources

### DIFF
--- a/external_resources/executables/base_def.py
+++ b/external_resources/executables/base_def.py
@@ -5,10 +5,10 @@ from external_resources.executables.type_defs import (
     ExecutableUseArgs,
     ExecutableUseValue,
 )
-from external_resources.type_defs import IsResource, ExternalResourceUnavailable
+from external_resources.type_defs import Resource, ExternalResourceUnavailable
 
 
-class Executable(IsResource[ExecutableUseArgs, ExecutableUseValue]):
+class Executable(Resource[ExecutableUseArgs, ExecutableUseValue]):
     executable_path: ExecutablePath
     validation_args: list[str] = ["--version"]
 

--- a/external_resources/resource_managers/__init__.py
+++ b/external_resources/resource_managers/__init__.py
@@ -1,0 +1,12 @@
+from external_resources.resource_managers.managers import (
+    ResourceManager,
+    CombinedResourceManager,
+    validate_resources_on_declaration,
+)
+
+
+__all__ = [
+    "CombinedResourceManager",
+    "ResourceManager",
+    "validate_resources_on_declaration",
+]

--- a/external_resources/resource_managers/managers.py
+++ b/external_resources/resource_managers/managers.py
@@ -1,0 +1,37 @@
+from typing import Type, cast
+
+from external_resources.resource_managers.type_defs import StaticManager, V
+from external_resources.type_defs import Resource
+
+
+def validate_resources_on_declaration(cls: Type[StaticManager[V]]) -> Type[StaticManager[V]]:
+    cls.raise_if_any_resource_is_unavailable()
+    return cls
+
+
+class ResourceManager(StaticManager[V]):
+    @classmethod
+    def _resource_dict(cls) -> dict[str, V]:
+        return {
+            attribute_name: cast(V, attribute_value)
+            for attribute_name, attribute_value in cls.__dict__.items()
+            if not attribute_name.startswith("_") and isinstance(attribute_value, Resource)
+        }
+
+
+class CombinedResourceManager(ResourceManager[V]):
+    @classmethod
+    def _resource_managers(cls) -> dict[str, Type[ResourceManager[V]]]:
+        return {
+            attribute_name: attribute_value
+            for attribute_name, attribute_value in cls.__dict__.items()
+            if not attribute_name.startswith("_")
+        }
+
+    @classmethod
+    def _resource_dict(cls) -> dict[str, V]:
+        return {
+            resource_name: resource
+            for manager in cls._resource_managers().values()
+            for resource_name, resource in manager._resource_dict().items()
+        }

--- a/external_resources/resource_managers/type_defs.py
+++ b/external_resources/resource_managers/type_defs.py
@@ -1,0 +1,22 @@
+from abc import ABCMeta, abstractmethod
+from typing import Generic, TypeVar
+
+from external_resources.type_defs import IsResource
+
+
+V = TypeVar("V", bound=IsResource)
+
+
+class StaticManager(Generic[V], metaclass=ABCMeta):
+    @classmethod
+    @abstractmethod
+    def _resource_dict(cls) -> dict[str, V]: ...
+
+    @classmethod
+    def as_list(cls) -> list[V]:
+        return list(cls._resource_dict().values())
+
+    @classmethod
+    def raise_if_any_resource_is_unavailable(cls) -> None:
+        for resource in cls.as_list():
+            resource.throw_if_unavailable()

--- a/external_resources/type_defs.py
+++ b/external_resources/type_defs.py
@@ -1,5 +1,5 @@
 from abc import ABCMeta, abstractmethod
-from typing import Generic, TypeVar
+from typing import Any, Generic, TypeVar, Protocol
 
 from pydantic import BaseModel
 from pydantic.dataclasses import dataclass as pydantic_dataclass
@@ -50,3 +50,9 @@ class Resource(Generic[T_UseArgs, V_UseOutput], metaclass=ABCMeta):
         """
         self.throw_if_unavailable()
         return self._use(args)
+
+
+class IsResource(Protocol):
+    def throw_if_unavailable(self) -> None: ...
+
+    def use(self, args: Any) -> Any: ...

--- a/external_resources/type_defs.py
+++ b/external_resources/type_defs.py
@@ -16,7 +16,7 @@ class ExternalResourceUnavailable(Exception):
 
 
 @pydantic_dataclass
-class IsResource(Generic[T_UseArgs, V_UseOutput], metaclass=ABCMeta):
+class Resource(Generic[T_UseArgs, V_UseOutput], metaclass=ABCMeta):
     @abstractmethod
     def throw_if_unavailable(self) -> None:
         """

--- a/tests/examples/example_print_current_branch.py
+++ b/tests/examples/example_print_current_branch.py
@@ -1,15 +1,16 @@
 # To run: "python tests/examples/Example_print_current_branch.py"
 
-from external_resources.executables import GitExecutable, executable_type_defs
+from external_resources.executables import Executable, GitExecutable, executable_type_defs
+from external_resources.resource_managers import ResourceManager, validate_resources_on_declaration
 
 
-# TODO - add manager to handle initial checks?
-GIT = GitExecutable()
-GIT.throw_if_unavailable()
+@validate_resources_on_declaration
+class Executables(ResourceManager[Executable]):
+    GIT = GitExecutable()
 
 
 def get_current_branch() -> str:
-    r = GIT.use(executable_type_defs.ExecutableUseArgs(args=["branch"]))
+    r = Executables.GIT.use(executable_type_defs.ExecutableUseArgs(args=["branch"]))
     assert r.return_code == 0
     lines = r.stdout.split("\n")
     for line in lines:

--- a/tests/examples/test_examples.py
+++ b/tests/examples/test_examples.py
@@ -9,3 +9,11 @@ EXAMPLE_NAMES = {file.name.split(".")[0] for file in EXAMPLE_FILES}
 @pytest.mark.parametrize("example", EXAMPLE_NAMES)
 def test_can_import(example: Path) -> None:
     __import__(f"tests.examples.{example}")
+
+
+def test_no_unexpected_files() -> None:
+    example_files = {file.name for file in EXAMPLE_FILES}
+    all_files = {file.name for file in Path(__file__).parent.glob("*") if not file.name.startswith("__")}
+    unexpected_files = all_files - example_files - {Path(__file__).name}
+
+    assert not unexpected_files, f"All test files should be named 'example_*', found: {unexpected_files}"

--- a/tests/test_resource_managers.py
+++ b/tests/test_resource_managers.py
@@ -1,0 +1,141 @@
+import pytest
+
+from pydantic import BaseModel
+
+from external_resources.resource_managers import (
+    ResourceManager,
+    CombinedResourceManager,
+    validate_resources_on_declaration,
+)
+from external_resources.type_defs import ExternalResourceUnavailable, Resource
+
+
+UNAVAILABLE_NUMBER = 123
+AVAILABLE_NUMBER = 456
+
+
+class FakeResourceUseArgs(BaseModel):
+    value_to_add: int
+
+
+class FakeResourceUseOutput(BaseModel):
+    result: int
+
+
+class FakeResource(BaseModel, Resource[FakeResourceUseArgs, FakeResourceUseOutput]):
+    stored_value: int
+
+    def throw_if_unavailable(self) -> None:
+        if self.stored_value == UNAVAILABLE_NUMBER:
+            raise ExternalResourceUnavailable("some message")
+        return None
+
+    def _use(self, args: FakeResourceUseArgs) -> FakeResourceUseOutput:
+        return FakeResourceUseOutput(result=self.stored_value + args.value_to_add)
+
+
+@pytest.fixture
+def available_resource() -> FakeResource:
+    return FakeResource(stored_value=AVAILABLE_NUMBER)
+
+
+@pytest.fixture
+def unavailable_resource() -> FakeResource:
+    return FakeResource(stored_value=UNAVAILABLE_NUMBER)
+
+
+def test_fake_resource_works(available_resource: FakeResource, unavailable_resource: FakeResource) -> None:
+    """Santity check that fake resource behaves expectely for the tests"""
+    use_args = FakeResourceUseArgs(value_to_add=1)
+    print(type(available_resource))
+
+    with pytest.raises(ExternalResourceUnavailable, match="some message"):
+        unavailable_resource.use(use_args)
+
+    assert available_resource.use(use_args) == FakeResourceUseOutput(result=AVAILABLE_NUMBER + 1)
+
+
+class TestResourceManager:
+    def test_validate_all_resources_available(self, available_resource: FakeResource) -> None:
+        @validate_resources_on_declaration
+        class AllAvailable(ResourceManager[FakeResource]):
+            RESOURCE_A = available_resource
+
+    def test_validate_some_resources_unavailable(self, unavailable_resource: FakeResource) -> None:
+        with pytest.raises(ExternalResourceUnavailable, match="some message"):
+
+            @validate_resources_on_declaration
+            class SomeResources(ResourceManager[FakeResource]):
+                RESOURCE_A = available_resource
+                RESOURCE_B = unavailable_resource
+
+    def test_validate_all_resources_unavailable(self, unavailable_resource: FakeResource) -> None:
+        with pytest.raises(ExternalResourceUnavailable, match="some message"):
+
+            @validate_resources_on_declaration
+            class AllUnavailable(ResourceManager[FakeResource]):
+                RESOURCE_A = unavailable_resource
+
+    def test_resource_dict(self, available_resource: FakeResource, unavailable_resource: FakeResource) -> None:
+        class SomeResources(ResourceManager[FakeResource]):
+            RESOURCE_A = available_resource
+            RESOURCE_B = unavailable_resource
+
+        assert SomeResources._resource_dict() == {
+            "RESOURCE_A": available_resource,
+            "RESOURCE_B": unavailable_resource,
+        }
+
+    def test_as_list(self, available_resource: FakeResource, unavailable_resource: FakeResource) -> None:
+        class SomeResources(ResourceManager[FakeResource]):
+            RESOURCE_A = available_resource
+            RESOURCE_B = unavailable_resource
+
+        assert SomeResources.as_list() == [available_resource, unavailable_resource]
+
+
+class TestCombinedResourceManager:
+    def test_resource_managers(self, available_resource: FakeResource, unavailable_resource: FakeResource) -> None:
+        class ManagerA(ResourceManager[FakeResource]):
+            RESOURCE_A = available_resource
+
+        class ManagerB(ResourceManager[FakeResource]):
+            RESOURCE_B = unavailable_resource
+
+        class AllResources(CombinedResourceManager[FakeResource]):
+            FOO = ManagerA
+            BAR = ManagerB
+
+        assert AllResources._resource_managers() == {
+            "FOO": ManagerA,
+            "BAR": ManagerB,
+        }
+
+    def test_resource_dict(self, available_resource: FakeResource, unavailable_resource: FakeResource) -> None:
+        class ManagerA(ResourceManager[FakeResource]):
+            RESOURCE_A = available_resource
+
+        class ManagerB(ResourceManager[FakeResource]):
+            RESOURCE_B = unavailable_resource
+
+        class AllResources(CombinedResourceManager[FakeResource]):
+            FOO = ManagerA
+            BAR = ManagerB
+
+        assert AllResources._resource_dict() == {
+            "RESOURCE_A": available_resource,
+            "RESOURCE_B": unavailable_resource,
+        }
+
+    def test_as_list(self, available_resource: FakeResource, unavailable_resource: FakeResource) -> None:
+        class ManagerA(ResourceManager[FakeResource]):
+            RESOURCE_A = available_resource
+
+        class ManagerB(ResourceManager[FakeResource]):
+            RESOURCE_B = unavailable_resource
+
+        class AllResources(CombinedResourceManager[FakeResource]):
+            FOO = ManagerA
+            BAR = ManagerB
+
+        assert AllResources.as_list() == [available_resource, unavailable_resource]


### PR DESCRIPTION
Provide class to help group and access resources.

Example use case:
```
@validate_resources_on_declaration
class MyResources(ResourceManager[SomeResource]):
        RESOURCE_A = SomeResorce(some_arg=123)
        RESOURCE_B = SomeResorce(some_arg=456)

if __name__ == '__main__':
        print(RESOURCE_A.use())
```

Also provides a class to combine resource managers and treat them as one manager:
```
@validate_resources_on_declaration
class OtherResources(ResourceManager[SomeResource]):
        RESOURCE_C = SomeResorce(some_arg=789)

class AllResources(CombinedResourceManager[SomeResource]):
        MY_RESOURCES = MyResources
        OTHER_RESOURCES = OtherResources
```